### PR TITLE
Relax node & npm engine version constraits to anything greater

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "start": "node index.js"
   },
   "engines": {
-    "node": "6.9.1",
-    "npm": " 3.10.3 "
+    "node": ">= 6.9.1",
+    "npm": " >= 3.10.3"
   },
   "dependencies": {
     "commander": "^2.9.0",


### PR DESCRIPTION
Right now, we depend exactly on node 6.9.1 and npm 3.10.3, which doesn't make much sense.

Adding a `>=` to the version constraint.

An alternative would be to use the tilde `~ 6.9.1`, but.. this makes sense for dependencies, but maybe not so much for engines. (We're not expecting node 8 to break stuff.)

Should fix the docker build `error manageiq-api-mock@1.0.0: The engine "node" is incompatible with this module. Expected version "6.9.1".`

Cc @bdunne, @simaishi 